### PR TITLE
Fix CI: format Python code block in compare_fortran README

### DIFF
--- a/tests/compare_fortran/README.md
+++ b/tests/compare_fortran/README.md
@@ -194,12 +194,18 @@ This framework sets the output file paths to the paths under `-o`, so the FORTRA
 
 ```python
 from pathlib import Path
-from tests.compare_fortran import RunSpec, run_python, run_fortran, compare_tables, compare_postscript
+from tests.compare_fortran import (
+    RunSpec,
+    run_python,
+    run_fortran,
+    compare_tables,
+    compare_postscript,
+)
 
-spec = RunSpec("ephemeris", {"planet": 6, "start": "2022-01-01", "stop": "2022-01-02"})
-out = Path("/tmp/compare")
-run_python(spec, out_table=out / "py.txt")
-run_fortran(spec, ["/path/to/fortran/Tools/ephem3_xxx.bin"], out_table=out / "fort.txt")
-result = compare_tables(out / "py.txt", out / "fort.txt", lsd_tolerance=1)
+spec = RunSpec('ephemeris', {'planet': 6, 'start': '2022-01-01', 'stop': '2022-01-02'})
+out = Path('/tmp/compare')
+run_python(spec, out_table=out / 'py.txt')
+run_fortran(spec, ['/path/to/fortran/Tools/ephem3_xxx.bin'], out_table=out / 'fort.txt')
+result = compare_tables(out / 'py.txt', out / 'fort.txt', lsd_tolerance=1)
 print(result.same, result.message)
 ```


### PR DESCRIPTION
## Problem

The weekly scheduled CI run has been failing since 2026-07-26 (runs `30200746757`, `30746341840`, `31311017277`, `31944462338`) with no code changes in between. All test jobs passed; only the `Ruff (format)` step in the Lint job failed.

Ruff 0.16 began formatting Python code blocks embedded in Markdown files. The dev dependency is unpinned (`ruff>=0.8` in `pyproject.toml`), so CI installed 0.16.3 and started checking `tests/compare_fortran/README.md`, which had never been formatted.

Because `ruff format --check` failed early, the **Mypy**, **Sphinx**, and **PyMarkdown** steps never ran and their status was unknown.

## Fix

Reformatted the code block in `tests/compare_fortran/README.md` to match project style — single quotes (`quote-style = "single"`) and the 100-column import split. Documentation only; no functional change.

## Verification

Reproduced the failure locally with ruff 0.16.3 (the exact version CI installed), then ran all four lint steps in a Python 3.13 venv built from `pip install -e ".[dev]"`:

| Step | Result |
| --- | --- |
| Ruff (lint) | All checks passed |
| Ruff (format) | 98 files already formatted |
| Mypy | Success: no issues found in 96 source files |
| Sphinx | build succeeded |
| PyMarkdown | clean (exit 0) |

The three previously-masked steps pass — this was the only failure. Test jobs were already green across Python 3.10–3.13 and are unaffected by a docs-only change.

## Note

The root cause is unpinned linter tooling: `ruff>=0.8` lets any future ruff release change formatting rules and break scheduled CI on an unchanged tree. Pinning to a compatible range would prevent a recurrence, but that's a tooling-policy decision left out of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HYFcy9WnCi2TkbZVvhzp6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the programmatic-use example for clearer formatting and consistent Python string style.
  * No behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->